### PR TITLE
Minor fix: Merge CNI conf files

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,7 +12,12 @@ fi
 if [ ! -f /etc/cni/net.d/00-meshnet.conf ]; then
   echo "Mergin existing CNI configuration with meshnet"
   existing=$(ls -1 /etc/cni/net.d/ | egrep "flannel|weave|bridge|calico|contiv|cilium|cni|kindnet" | head -n1)
-  jq  -s '.[1].delegate = (.[0].plugins[0])' /etc/cni/net.d/$existing /etc/cni/net.d/meshnet.conf | jq .[1] > /etc/cni/net.d/00-meshnet.conf
+  have_plugin_section=$(sudo cat /etc/cni/net.d/$existing | jq '.plugins')
+  if [ -z have_plugin_section ]; then
+    jq -s '.[1].delegate = (.[0].plugins[0])' /etc/cni/net.d/$existing /etc/cni/net.d/meshnet.conf | jq .[1] > /etc/cni/net.d/00-meshnet.conf
+  else
+    jq -s '.[1].delegate = (.[0])' /etc/cni/net.d/$existing /etc/cni/net.d/meshnet.conf | jq .[1] > /etc/cni/net.d/00-meshnet.conf
+  fi
 else
   echo "Re-using existing CNI config"
 fi


### PR DESCRIPTION
Few CNI plugins have 'plugin' section in there conf file while some others don't have it.
Merging process of meshnet and other CNI's conf file needs to take care of this.