### PR TITLE
Fix for issue#10

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN make proto
 
 FROM golang:1.12.7 AS build_base
 
-WORKDIR /go/src/github.com/networkop/meshnet-cni
+WORKDIR /go/src/github.com/tahir24434/meshnet-cni
 ENV GO111MODULE=on
 
 COPY go.mod .
@@ -36,8 +36,8 @@ FROM alpine:latest
 
 RUN apk add --no-cache jq
 
-COPY --from=build /go/src/github.com/networkop/meshnet-cni/meshnet /
-COPY --from=build /go/src/github.com/networkop/meshnet-cni/meshnetd /
+COPY --from=build /go/src/github.com/tahir24434/meshnet-cni/meshnet /
+COPY --from=build /go/src/github.com/tahir24434/meshnet-cni/meshnetd /
 
 COPY etc/cni/net.d/meshnet.conf /
 COPY docker/entrypoint.sh /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,50 +1,37 @@
 FROM golang:1.12.7 AS proto_base
-
 ENV GO111MODULE=off
 RUN apt-get update && apt-get -y install curl unzip
 RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip && \
-    unzip protoc-3.9.1-linux-x86_64.zip 
+    unzip protoc-3.9.1-linux-x86_64.zip
 RUN go get -u github.com/golang/protobuf/protoc-gen-go
-
-
 COPY daemon/ daemon/
 COPY Makefile .
 COPY .mk/ .mk/
-
 RUN make proto
 
 FROM golang:1.12.7 AS build_base
-
-WORKDIR /go/src/github.com/tahir24434/meshnet-cni
+WORKDIR /go/src/github.com/networkop/meshnet-cni
 ENV GO111MODULE=on
-
 COPY go.mod .
 COPY go.sum .
-
 RUN go mod download
 
+
 FROM build_base AS build
-
 COPY . .
-
-COPY --from=proto_base daemon/generated daemon/generated
-RUN CGO_ENABLED=0 GOOS=linux go build -o meshnet plugin/meshnet.go 
+COPY --from=proto_base /go/daemon/generated daemon/generated
+RUN CGO_ENABLED=0 GOOS=linux go build -o meshnet plugin/meshnet.go
 RUN CGO_ENABLED=0 GOOS=linux go build -o meshnetd daemon/*.go
 
 
 FROM alpine:latest
-
 RUN apk add --no-cache jq
-
-COPY --from=build /go/src/github.com/tahir24434/meshnet-cni/meshnet /
-COPY --from=build /go/src/github.com/tahir24434/meshnet-cni/meshnetd /
-
+COPY --from=build /go/src/github.com/networkop/meshnet-cni/meshnet /
+COPY --from=build /go/src/github.com/networkop/meshnet-cni/meshnetd /
 COPY etc/cni/net.d/meshnet.conf /
 COPY docker/entrypoint.sh /
-
 RUN chmod +x ./entrypoint.sh
 RUN chmod +x /meshnetd
-
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 ENTRYPOINT ./entrypoint.sh

--- a/plugin/meshnet.go
+++ b/plugin/meshnet.go
@@ -142,7 +142,6 @@ func delegateAdd(ctx context.Context, netconf map[string]interface{}, intfName s
 	return result, nil
 }
 
-
 // DelegateDel call
 func delegateDel(ctx context.Context, netconf map[string]interface{}, intfName string) error {
 	log.Printf("Calling delegateDel for %s", netconf["type"].(string))
@@ -159,27 +158,6 @@ func delegateDel(ctx context.Context, netconf map[string]interface{}, intfName s
 		return fmt.Errorf("Error invoking Delegate Del %v", err)
 	}
 	return nil
-}
-
-func physicalVxlanLinkAdd(netNS, linkName string, ip string, srcIntf string, peerPodIP string) (err error) {
-	log.Printf("Default route is via %s@%s", srcIP, srcIntf)
-
-	myVeth, err := makeVeth(netNS, linkName, ip)
-    if err != nil {
-        return err
-    }
-
-    vxlan := makeVxlan(srcIntf, peerPodIP, 5099)
-    if err = koko.MakeVxLan(*myVeth, *vxlan); err != nil {
-        log.Printf("Error when creating a Vxlan interface with koko: %s", err)
-        return err
-    }
-
-    if err = koko.MakeVxLan(*myVeth, *vxlan); err != nil {
-        log.Printf("Error when creating a Vxlan interface with koko: %s", err)
-        return err
-    }
-    return nil
 }
 
 // Adds interfaces to a POD
@@ -220,12 +198,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 	log.Printf("Default route is via %s@%s", srcIP, srcIntf)
-
-	r, err := physicalVxlanLinkAdd(args.netNS, "eth99", "100.40.4.99/24", srcIntf, "172.33.16.19/24")
-	if err != nil {
-		log.Printf("'delegate' plugin failed: %s", err)
-		return err
-	}
 
 	log.Printf("Attempting to connect to local meshnet daemon")
 	conn, err := grpc.Dial(localDaemon, grpc.WithInsecure())

--- a/plugin/meshnet.go
+++ b/plugin/meshnet.go
@@ -142,6 +142,7 @@ func delegateAdd(ctx context.Context, netconf map[string]interface{}, intfName s
 	return result, nil
 }
 
+
 // DelegateDel call
 func delegateDel(ctx context.Context, netconf map[string]interface{}, intfName string) error {
 	log.Printf("Calling delegateDel for %s", netconf["type"].(string))
@@ -158,6 +159,27 @@ func delegateDel(ctx context.Context, netconf map[string]interface{}, intfName s
 		return fmt.Errorf("Error invoking Delegate Del %v", err)
 	}
 	return nil
+}
+
+func physicalVxlanLinkAdd(netNS, linkName string, ip string, srcIntf string, peerPodIP string) (err error) {
+	log.Printf("Default route is via %s@%s", srcIP, srcIntf)
+
+	myVeth, err := makeVeth(netNS, linkName, ip)
+    if err != nil {
+        return err
+    }
+
+    vxlan := makeVxlan(srcIntf, peerPodIP, 5099)
+    if err = koko.MakeVxLan(*myVeth, *vxlan); err != nil {
+        log.Printf("Error when creating a Vxlan interface with koko: %s", err)
+        return err
+    }
+
+    if err = koko.MakeVxLan(*myVeth, *vxlan); err != nil {
+        log.Printf("Error when creating a Vxlan interface with koko: %s", err)
+        return err
+    }
+    return nil
 }
 
 // Adds interfaces to a POD
@@ -198,6 +220,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 	log.Printf("Default route is via %s@%s", srcIP, srcIntf)
+
+	r, err := physicalVxlanLinkAdd(args.netNS, "eth99", "100.40.4.99/24", srcIntf, "172.33.16.19/24")
+	if err != nil {
+		log.Printf("'delegate' plugin failed: %s", err)
+		return err
+	}
 
 	log.Printf("Attempting to connect to local meshnet daemon")
 	conn, err := grpc.Dial(localDaemon, grpc.WithInsecure())


### PR DESCRIPTION
 https://github.com/networkop/meshnet-cni/issues/10
daemon/generated in proto_base is at path /go/daemon/generated. In build_base, we are modifying the Workdir.
Without this change, we hit below error 

`failed to solve with frontend dockerfile.v0: failed to build LLB: failed to compute cache key: failed to walk /var/lib/docker/tmp/buildkit-mount009672704/daemon: lstat /var/lib/docker/tmp/buildkit-mount009672704/daemon: no such file or directory`
