### PR TITLE
Fix incompatible go proxy format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,3 +39,5 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/kind v0.2.1 // indirect
 )
+
+replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab


### PR DESCRIPTION
This fixes a bug that existed in a previous go proxy implementation.
It uses a workaround to pin k8s.io/client-go v12 to it's corresponding commit hash.
This will allow go mod download to work properly.

See https://github.com/golang/go/issues/33558 for more information.

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>