### PR TITLE
Allow other CRI environments

### DIFF
--- a/manifests/base/meshnet.yml
+++ b/manifests/base/meshnet.yml
@@ -143,6 +143,9 @@ items:
             mountPath: /etc/cni/net.d
           - name: cni-bin
             mountPath: /opt/cni/bin
+          - name: var-run-netns
+            mountPath: /var/run/netns
+            mountPropagation: Bidirectional
         terminationGracePeriodSeconds: 0
         volumes:
         - name: cni-bin
@@ -151,3 +154,6 @@ items:
         - name: cni-cfg
           hostPath:
             path: /etc/cni/net.d
+        - name: var-run-netns
+          hostPath:
+            path: /var/run/netns


### PR DESCRIPTION
When running this CNI plugin in environments that use a different CRI
(such as containerd) instead of the docker CRI, the network namespace
argument passed to the CNI plugin is in the form or
`/var/run/netns/cni-xxxxxx` instead of the default `/proc/<pid>/ns/net`
format that docker uses.
For meshnetd to be able to query the NetNS, it needs access to the host
nodes' `/var/run/netns` directory.

This change will mount the hosts `/var/run/netns` directory in the
meshnet pods.

Keep in mind that for this to work, the hosts `/run` directory needs to
be mounted rshared or otherwise the changes will not propagate into the
meshnet pods.

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>