### PR TITLE
Changes in release workflow to create multi-arch builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ master ]
+    
 
 
 jobs:
@@ -24,6 +24,10 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PWD }}
+      -
+        name: Install quemu emulators
+        run: |
+          docker run -it --rm --privileged tonistiigi/binfmt --install all
       - 
         name: Build and Push container images
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [ master ]
 
 
 jobs:
@@ -16,6 +17,13 @@ jobs:
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PWD }}
       - 
         name: Build and Push container images
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       -
         name: Install quemu emulators
         run: |
-          docker run -it --rm --privileged tonistiigi/binfmt --install all
+          docker run -td --rm --privileged tonistiigi/binfmt --install all
       - 
         name: Build and Push container images
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,7 @@ jobs:
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - 
-        name: Login to Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PWD }}
+
       -
         name: Install quemu emulators
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   push:
-    
 
 
 jobs:
@@ -17,11 +16,6 @@ jobs:
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      -
-        name: Install quemu emulators
-        run: |
-          docker run -td --rm --privileged tonistiigi/binfmt --install all
       - 
         name: Build and Push container images
         run: |

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ docker:
 
 .PHONY: release
 ## Release the current code with git tag and `latest`
-release: 
+release:
+	docker run --rm --privileged tonistiigi/binfmt --install all
 	docker buildx build --push \
 		--build-arg LDFLAGS=${LDFLAGS} \
 		--platform ${ARCHS} \


### PR DESCRIPTION
Fixes https://github.com/networkop/meshnet-cni/issues/50

It seems as if the proper way to do it is to install emulators before the build per https://github.com/docker/buildx/issues/464#issuecomment-740434862.

FYI, this might be due to a change in moby/buildkit (a2c9241854f2) -> moby/buildkit (3ca743fc1489) 

@kingshukdev FYI