### PR TITLE
Fix gRPC issue in IPv6 only cluster

### DIFF
--- a/daemon/grpcwire/grpcwire.go
+++ b/daemon/grpcwire/grpcwire.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
+	"strconv"
 	"sync"
 
 	"github.com/google/gopacket"
@@ -303,7 +303,7 @@ func RecvFrmLocalPodThread(wire *GRPCWire, locIfNm string) error {
 	defaultPort := wireutil.GRPCDefaultPort
 	pktBuffSz := int32(1024 * 64 * 10) //keep buffer for MAX 10 64K frames
 
-	url := strings.TrimSpace(fmt.Sprintf("%s:%d", wire.PeerNodeIP, defaultPort))
+	url := net.JoinHostPort(wire.PeerNodeIP, strconv.FormatInt(int64(defaultPort), 10))
 	/* Utilizing google gopacket for polling for packets from the node. This seems to be the
 	   simplest way to get all packets.
 	   As an alternative to google gopacket(pcap), a socket based implementation is possible.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18.2 AS proto_base
 
 WORKDIR /src
 
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.32.0
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN go install github.com/bufbuild/buf/cmd/buf@v1.13.1
 

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.5
 )
 
-require google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 // indirect
-
 require (
 	github.com/Microsoft/go-winio v0.4.11 // indirect
 	github.com/docker/distribution v2.8.0+incompatible // indirect
@@ -32,7 +30,6 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
-	github.com/go-errors/errors v1.4.2
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
-github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -163,7 +161,6 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -601,8 +598,6 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.47.0 h1:9n77onPX5F3qfFCqjy9dhn8PbNQsIKeVU04J9G7umt8=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -616,8 +611,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/kind.yaml
+++ b/kind.yaml
@@ -1,11 +1,12 @@
----
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+networking:
+  ipFamily: ipv6
 nodes:
 - role: control-plane
 - role: worker
 - role: worker
-- role: worker
+# from meshnet
 kubeadmConfigPatches:
 - |
   apiVersion: kubelet.config.k8s.io/v1beta1
@@ -13,3 +14,6 @@ kubeadmConfigPatches:
   metadata:
     name: config
   maxPods: 253
+  allowedUnsafeSysctls:
+  - "net.ipv4.*"
+  - "net.ipv6.*"

--- a/manifests/overlays/e2e/kustomization.yaml
+++ b/manifests/overlays/e2e/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: networkop/meshnet
-  newTag: 12d9882-dirty
+  newTag: 88dc099-dirty
 resources:
 - ../../base/

--- a/manifests/overlays/grpc-link-e2e/kustomization.yaml
+++ b/manifests/overlays/grpc-link-e2e/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: networkop/meshnet
-  newTag: 12d9882-dirty
+  newTag: 88dc099-dirty
 resources:
 - ../grpc-link/

--- a/manifests/overlays/grpc-link/kustomization.yaml
+++ b/manifests/overlays/grpc-link/kustomization.yaml
@@ -15,4 +15,4 @@ resources:
 - ../../base/
 images:
 - name: networkop/meshnet
-  newTag: 12d9882-dirty
+  newTag: 88dc099-dirty

--- a/plugin/grpcwires-plugin.go
+++ b/plugin/grpcwires-plugin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
+	"strconv"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -150,8 +150,7 @@ func CreatGRPCChan(link *mpb.Link, localPod *mpb.Pod, peerPod *mpb.Pod, localCli
 
 	/* Dial the remote peer to create the remote end of the grpc tunnel. */
 
-	url := fmt.Sprintf("%s:%d", peerPod.SrcIp, wireutil.GRPCDefaultPort)
-	url = strings.TrimSpace(url)
+	url := net.JoinHostPort(peerPod.SrcIp, strconv.FormatInt(int64(wireutil.GRPCDefaultPort), 10))
 	remote, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("Add-GRPC[%s]: creating GRPC wire: failed to dial remote gRPC url %s", localPod.Name, url)
@@ -261,8 +260,7 @@ func MakeGRPCChanDown(link *mpb.Link, localPod *mpb.Pod, peerPod *mpb.Pod, ctx c
 
 	/* Dial the remote peer to bring down the remote grpc wire end */
 
-	url := fmt.Sprintf("%s:%d", peerPod.SrcIp, wireutil.GRPCDefaultPort)
-	url = strings.TrimSpace(url)
+	url := net.JoinHostPort(peerPod.SrcIp, strconv.FormatInt(int64(wireutil.GRPCDefaultPort), 10))
 	remote, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("MakeGRPCChanDown failed to dial remote gRPC url %s", url)

--- a/plugin/meshnet.go
+++ b/plugin/meshnet.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strconv"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -30,7 +31,7 @@ const (
 )
 
 var (
-	localDaemon = localhost + ":" + fmt.Sprintf("%d", wireutil.GRPCDefaultPort)
+	localDaemon = net.JoinHostPort(localhost, strconv.FormatInt(int64(wireutil.GRPCDefaultPort), 10))
 )
 
 var interNodeLinkType = wireutil.INTER_NODE_LINK_VXLAN
@@ -367,7 +368,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 					NodeIntf: srcIntf,
 				}
 
-				url := fmt.Sprintf("%s:%d", peerPod.SrcIp, wireutil.GRPCDefaultPort)
+				url := net.JoinHostPort(peerPod.SrcIp, strconv.FormatInt(int64(wireutil.GRPCDefaultPort), 10))
 				log.Infof("Add[%s]: Trying to do a remote update on %s", string(cniArgs.K8S_POD_NAME), url)
 
 				remote, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()))


### PR DESCRIPTION
Hi,

This PR fixes an issue encountered with gRPC in an IPv6 only clusters.

# Current implementation

The current implementation is using `fmt.Sprintf` to combine the hostname and port number used when calling `grpc.Dial(...)`. See [daemon/grpcwire/grpcwire.go](https://github.com/networkop/meshnet-cni/blob/d7c306c635cf73a44833e3ebdefb8b163a9aa784/daemon/grpcwire/grpcwire.go#L306) for instance.

Yet, this yields the following (important part highlighted) when doing `kubectl describe pod/<podName>`:

> Warning  FailedCreatePodSandBox  10m kubelet Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "ae67dda14b109f585fd51fdde5f54087955ae7b5f91d563957dbbe85a72ce021": plugin type="meshnet" name="meshnet" failed (add): rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp: address fc00:f853:ccd:e793::4:51111: **too many colons in address**"

# Fix

The solution is to use Go's [`net.JoinHostPort(...)`](https://pkg.go.dev/net#JoinHostPort) instead of `fmt.Sprintf` to combine the hostname and port number.

This method will automatically add `[]` around the hostname when it's an IPv6, which is using `:`.

See [grpc-go issue 3399](https://github.com/grpc/grpc-go/issues/3399) for more details.

# Test

The fix has been tested on the following:
- `kind version` => kind v0.20.0 go1.21.4 linux/amd64
- Docker engine 25.0.3
- Ubuntu 22.04 LTS
- Kind cluster configuration:
```
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
networking:
  ipFamily: ipv6
nodes:
- role: control-plane
- role: worker
- role: worker
- role: worker
kubeadmConfigPatches:
- |
  apiVersion: kubelet.config.k8s.io/v1beta1
  kind: KubeletConfiguration
  metadata:
    name: config
  maxPods: 253
```